### PR TITLE
Don't allow blank theme names.

### DIFF
--- a/web-starter/index.js
+++ b/web-starter/index.js
@@ -68,7 +68,10 @@ module.exports = generators.Base.extend({
         type: 'input',
         name: 'drupal_theme',
         message: 'Theme name (machine name)',
-        default: config.drupal_theme,
+        default: config.drupal_theme || 'gesso',
+        validate: function (value) {
+          return value !== '';
+        },
       },
       {
         type: 'confirm',

--- a/web-starter/index.js
+++ b/web-starter/index.js
@@ -25,7 +25,7 @@ module.exports = generators.Base.extend({
     var config = _.extend({
       features : true,
       cmi : false,
-      drupal_theme : '',
+      drupal_theme : 'gesso',
       drupal_version : ''
     }, this.config.getAll());
 
@@ -68,7 +68,7 @@ module.exports = generators.Base.extend({
         type: 'input',
         name: 'drupal_theme',
         message: 'Theme name (machine name)',
-        default: config.drupal_theme || 'gesso',
+        default: config.drupal_theme,
         validate: function (value) {
           return value !== '';
         },


### PR DESCRIPTION
This addresses forumone/generator-web-starter-gesso#27 by:

1. Defaulting the theme name to 'gesso' when starting a project, and
2. Validating that the theme name is not the empty string.

This avoids the accidental copying of the contents of the gesso theme into sites/all/themes.